### PR TITLE
Bugfix/accuracy issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             pip install --upgrade pip
             pip install torch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0
             pip install -r tools/requirements_export.txt
-            pip install pytest
+            pip install pytest espnet==202207
       - run:
           command: |
             cd ~

--- a/espnet_onnx/asr/model/decoders/xformer.py
+++ b/espnet_onnx/asr/model/decoders/xformer.py
@@ -64,13 +64,11 @@ class XformerDecoder(BatchScorerInterface):
             ys = ys[None, :]
 
         n_batch = len(ys)
-        is_first_iteration = False
         if states[0] is None:
             batch_state = [
                 np.zeros((1, 1, self.odim), dtype=np.float32)
                 for _ in range(self.n_layers)
             ]
-            is_first_iteration = True
         else:
             # transpose state of [batch, layer] into [layer, batch]
             batch_state = [
@@ -86,10 +84,6 @@ class XformerDecoder(BatchScorerInterface):
             input_dict
         )
         
-        # if first iteration, remove the first row
-        if is_first_iteration:
-            states = [states[i][:, -1:] for i in range(len(states))]
-
         # transpose state of [layer, batch] into [batch, layer]
         state_list = [[states[i][b]
                        for i in range(self.n_layers)] for b in range(n_batch)]

--- a/espnet_onnx/export/asr/models/decoder_layer.py
+++ b/espnet_onnx/export/asr/models/decoder_layer.py
@@ -55,7 +55,7 @@ class OnnxDecoderLayer(nn.Module):
             self.concat_linear1 = model.concat_linear1
             self.concat_linear2 = model.concat_linear2
 
-    def forward(self, x, mask, memory, memory_mask, cache=None, is_first_layer=False):
+    def forward(self, x, mask, memory, memory_mask, cache=None):
         """Compute encoded features.
 
         Args:
@@ -68,13 +68,6 @@ class OnnxDecoderLayer(nn.Module):
             torch.Tensor: Mask tensor (#batch, time).
 
         """
-        if cache is not None and not is_first_layer:
-            # when this decoder layer is not the first layer and we need to consider cache,
-            # then x = torch.cat([cache, x]),
-            # and the first sequence of the cache is always a dummy cache in this espnet_onnx.
-            # So we need to remove this dummy cache to compute normalization.
-            x = x[:, 1:]
-        
         residual = x
 
         if self.normalize_before:

--- a/espnet_onnx/export/asr/models/decoders/xformer.py
+++ b/espnet_onnx/export/asr/models/decoders/xformer.py
@@ -1,4 +1,5 @@
 import os
+from espnet_onnx.utils.function import subsequent_mask
 
 import torch
 import torch.nn as nn
@@ -6,8 +7,9 @@ import numpy as np
 
 from espnet.nets.pytorch_backend.transformer.attention import MultiHeadedAttention
 from ..multihead_att import OnnxMultiHeadedAttention
+# from espnet.nets.pytorch_backend.transformer.mask import subsequent_mask
 
-from espnet_onnx.utils.function import subsequent_mask
+from espnet_onnx.utils.torch_function import subsequent_mask
 from ..language_models.embed import Embedding
 from espnet_onnx.utils.abs_model import AbsExportModel
 from espnet_onnx.utils.torch_function import MakePadMask
@@ -23,6 +25,7 @@ class XformerDecoder(nn.Module, AbsExportModel):
         if isinstance(self.model.decoders[0].self_attn, MultiHeadedAttention):
             self.num_heads = self.model.decoders[0].self_attn.h
             self.hidden_size = self.model.decoders[0].self_attn.linear_out.out_features
+
         # replace multihead attention module into customized module.
         for i,d in enumerate(self.model.decoders):
             # d is DecoderLayer
@@ -31,7 +34,7 @@ class XformerDecoder(nn.Module, AbsExportModel):
             if isinstance(d.src_attn, MultiHeadedAttention):
                 d.src_attn = OnnxMultiHeadedAttention(d.src_attn)
             self.model.decoders[i] = OnnxDecoderLayer(d)
-                
+        
         self.model_name = 'xformer_decoder'
     
     def prepare_mask(self, mask):
@@ -43,25 +46,33 @@ class XformerDecoder(nn.Module, AbsExportModel):
         return mask * -10000.0
 
     def forward(self, tgt, memory, cache):
-        feats_length = torch.ones(tgt.shape).sum(dim=-1).type(torch.long)
-        mask = self.make_pad_mask(feats_length) # (B, T)
-        mask[:, -1] = 1
+        # feats_length = torch.ones(tgt.shape).sum(dim=-1).type(torch.long)
+        # mask = self.make_pad_mask(feats_length) # (B, T)
+        # pad_mask = self.make_pad_mask(feats_length).unsqueeze(1)
+        # mask = subsequent_mask(pad_mask.shape[-1]).unsqueeze(0) # (B, T)
+        mask = subsequent_mask(tgt.size(-1)).unsqueeze(0) # (B, T)``
         
         x = self.embed(tgt)
         mask = self.prepare_mask(mask)
         new_cache = []
-        for c, decoder in zip(cache, self.model.decoders):
+        for i_layer, (c, decoder) in enumerate(zip(cache, self.model.decoders)):
+            is_first_layer = i_layer == 0
             x, mask = decoder(
-                x, mask, memory, None, c
+                x, mask, memory, None, c, is_first_layer
             )
             new_cache.append(x)
-            
-        y = self.model.after_norm(x[:, -1])
-        y = torch.log_softmax(self.model.output_layer(y), dim=-1)
+        
+        if self.model.normalize_before:
+            y = self.model.after_norm(x[:, -1])
+        else:
+            y = x[:, -1]
+
+        if self.model.output_layer is not None:
+            y = torch.log_softmax(self.model.output_layer(y), dim=-1)
         return y, new_cache
 
     def get_dummy_inputs(self, enc_size):
-        tgt = torch.LongTensor([1]).unsqueeze(0)
+        tgt = torch.LongTensor([0]).unsqueeze(0)
         enc_out = torch.randn(1, 100, enc_size)
         cache = [
             torch.zeros((1, 1, self.model.decoders[0].size))

--- a/espnet_onnx/export/asr/models/language_models/embed.py
+++ b/espnet_onnx/export/asr/models/language_models/embed.py
@@ -118,7 +118,7 @@ class OnnxPositionalEncoding(torch.nn.Module):
         self.pe = model.pe
         self.use_cache = use_cache
         self.model = model
-        if not self.use_cache:
+        if self.use_cache:
             self.extend_pe()
         else:
             self.div_term = torch.exp(
@@ -132,7 +132,7 @@ class OnnxPositionalEncoding(torch.nn.Module):
         if self.max_seq_len < pe_length:
             self.pe = self.pe[:, :self.max_seq_len]
         else:
-            self.model.extend_pe(self.max_seq_len)
+            self.model.extend_pe(torch.tensor(0.0).expand(1, self.max_seq_len))
             self.pe = self.model.pe
     
     def _add_pe(self, x):

--- a/espnet_onnx/export/asr/models/language_models/embed.py
+++ b/espnet_onnx/export/asr/models/language_models/embed.py
@@ -276,16 +276,12 @@ class OnnxLegacyRelPositionalEncoding(OnnxPositionalEncoding):
 
 class OnnxRelPositionalEncoding(torch.nn.Module):
     """Relative positional encoding module (new implementation).
-
     Details can be found in https://github.com/espnet/espnet/pull/2816.
-
     See : Appendix B in https://arxiv.org/abs/1901.02860
-
     Args:
         d_model (int): Embedding dimension.
         dropout_rate (float): Dropout rate.
         max_seq_len (int): Maximum input length.
-
     """
 
     def __init__(self, model, max_seq_len=512, use_cache=True):
@@ -293,26 +289,46 @@ class OnnxRelPositionalEncoding(torch.nn.Module):
         super(OnnxRelPositionalEncoding, self).__init__()
         self.d_model = model.d_model
         self.xscale = math.sqrt(self.d_model)
-        self.pe = model.pe
+        self.pe = None
         self.use_cache = use_cache
-        self.model = model
-        self.max_seq_len = max_seq_len
         if self.use_cache:
-            self.extend_pe()
+            self.extend_pe(torch.tensor(0.0).expand(1, max_seq_len))
         else:
             self.div_term = torch.exp(
                 torch.arange(0, self.d_model, 2, dtype=torch.float32)
                 * -(math.log(10000.0) / self.d_model)
             )
 
-    def extend_pe(self):
+    def extend_pe(self, x):
         """Reset the positional encodings."""
-        pe_length = len(self.pe[0])
-        if self.max_seq_len < pe_length:
-            self.pe = self.pe[:, :self.max_seq_len]
-        else:
-            self.model.extend_pe(self.max_seq_len)
-            self.pe = self.model.pe
+        if self.pe is not None and self.pe.size(1) >= x.size(1) * 2 - 1:
+            # self.pe contains both positive and negative parts
+            # the length of self.pe is 2 * input_len - 1
+            if self.pe.dtype != x.dtype or self.pe.device != x.device:
+                self.pe = self.pe.to(dtype=x.dtype, device=x.device)
+            return
+        # Suppose `i` means to the position of query vecotr and `j` means the
+        # position of key vector. We use position relative positions when keys
+        # are to the left (i>j) and negative relative positions otherwise (i<j).
+        pe_positive = torch.zeros(x.size(1), self.d_model)
+        pe_negative = torch.zeros(x.size(1), self.d_model)
+        position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32)
+            * -(math.log(10000.0) / self.d_model)
+        )
+        pe_positive[:, 0::2] = torch.sin(position * div_term)
+        pe_positive[:, 1::2] = torch.cos(position * div_term)
+        pe_negative[:, 0::2] = torch.sin(-1 * position * div_term)
+        pe_negative[:, 1::2] = torch.cos(-1 * position * div_term)
+
+        # Reserve the order of positive indices and concat both positive and
+        # negative indices. This is used to support the shifting trick
+        # as in https://arxiv.org/abs/1901.02860
+        pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
+        pe_negative = pe_negative[1:].unsqueeze(0)
+        pe = torch.cat([pe_positive, pe_negative], dim=1)
+        self.pe = pe.to(device=x.device, dtype=x.dtype)
     
     def _get_pe(self, x):
         pe_positive = torch.zeros(x.size(1), self.d_model)
@@ -330,15 +346,12 @@ class OnnxRelPositionalEncoding(torch.nn.Module):
         pe_negative = pe_negative[1:].unsqueeze(0)
         return torch.cat([pe_positive, pe_negative], dim=1)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor, use_cache=True):
         """Add positional encoding.
-
         Args:
             x (torch.Tensor): Input tensor (batch, time, `*`).
-
         Returns:
             torch.Tensor: Encoded tensor (batch, time, `*`).
-
         """
         x = x * self.xscale
         if self.use_cache:

--- a/espnet_onnx/utils/config.py
+++ b/espnet_onnx/utils/config.py
@@ -64,7 +64,9 @@ class Config(SimpleNamespace):
             if isinstance(v, dict):
                 setattr(self, k, Config(v))
             elif isinstance(v, list):
-                if isinstance(v[0], dict):
+                if len(v) == 0:
+                    setattr(self, k, [])
+                elif isinstance(v[0], dict):
                     setattr(self, k, [Config(_v) for _v in v])
 
     def __len__(self):

--- a/espnet_onnx/utils/torch_function.py
+++ b/espnet_onnx/utils/torch_function.py
@@ -52,3 +52,6 @@ def normalize(input: torch.Tensor, p: float = 2.0, dim: int = 1, out: Optional[t
     else:
         denom = input.norm(p, dim, keepdim=True).expand_as(input)
         return torch.div(input, denom, out=out)
+
+def subsequent_mask(size: torch.Tensor):
+    return torch.ones(size, size).tril()

--- a/tests/unit_tests/forward_utils.py
+++ b/tests/unit_tests/forward_utils.py
@@ -1,10 +1,9 @@
 
 import numpy as np
-import torch
-from espnet.nets.pytorch_backend.transformer.mask import subsequent_mask
 from espnet_onnx.utils.function import (
     mask_fill, make_pad_mask
 )
+from espnet_onnx.utils.torch_function import subsequent_mask
 
 
 def run_onnx_enc(model, dummy_input, model_type):
@@ -22,7 +21,7 @@ def run_onnx_enc(model, dummy_input, model_type):
 
 def run_xformer_dec(model, dummy_input, dummy_yseq, model_type):
     if model_type == 'torch':
-        ys_mask = subsequent_mask(len(dummy_yseq)).unsqueeze(0)
+        ys_mask = subsequent_mask(dummy_yseq.size(-1)).unsqueeze(0)
         logp, state = model.forward_one_step(
             tgt=dummy_yseq,
             tgt_mask=ys_mask,

--- a/tests/unit_tests/test_export_frontend.py
+++ b/tests/unit_tests/test_export_frontend.py
@@ -96,5 +96,5 @@ def test_optimize_frontend(model_type, model_name, n_head, h_size, n_att, n_cros
     if n_cross_att > 0:
         nodes['CrossAttention'] = n_cross_att
         
-    check_op_type_count(str(output_dir / model_name), **nodes)
+    check_op_type_count(str(output_dir / model_name), nodes)
     

--- a/tests/unit_tests/test_inference_asr.py
+++ b/tests/unit_tests/test_inference_asr.py
@@ -141,7 +141,7 @@ def test_infer_decoder(dec_type, feat_lens, load_config, get_class):
     # test output
     for fl in feat_lens:
         dummy_input = torch.randn(1, fl, 256)
-        dummy_yseq = torch.LongTensor([0, 1])
+        dummy_yseq = torch.LongTensor([0])
         if dec_type[:3] == 'rnn':
             torch_out = run_rnn_dec(decoder_espnet, dummy_input, dummy_yseq)
             onnx_out = run_rnn_dec(decoder_onnx, dummy_input.numpy(), dummy_yseq.numpy())


### PR DESCRIPTION
This PR fixes some bugs that cause an accuracy drop.

**fixed problems**
- Parity issue of the Legacy version of Conformer.
  - The problem was caused by the relative position encoding, which was used for legacy conformer.
- Parity issue of Transformer Decoder.
  - The problem was caused by the caching problem. In the espnet implementation, we give `None` as the first cache for the `forward_one_step` function in the decoder class. We can give both `None` or `torch.Tensor` and the TransformerDecoder would change its computation depending on the input.
    However, in the onnx, we need to give one tensor as a dummy cache for `cache=None` case to avoid splitting the onnx model. This dummy cache caused an issue while computing the first `LayerNorm` in the second or later layers. So I removed the first sequence (dummy cache) if we need to compute with cache and the decoder layer is not the first layer.