### PR TITLE
[Bugfix] Final word was not properly calculated

### DIFF
--- a/espnet_onnx/asr/asr_streaming.py
+++ b/espnet_onnx/asr/asr_streaming.py
@@ -148,8 +148,7 @@ class StreamingSpeech2Text(AbsASRModel):
             end = self.hop_size * (i + 1) + self.initial_wav_length
             nbest = self(padded_speech[start:end])
             if print_every_hypo and nbest != []:
-                # logging.info(f"Result at position {i+1} : {nbest[0][0]}")
-                print(f"Result at position {i+1} : {nbest[0][0]}")
+                logging.info(f"Result at position {i+1} : {nbest[0][0]}")
 
         return nbest
 

--- a/espnet_onnx/export/asr/models/encoders/contextual_block_xformer.py
+++ b/espnet_onnx/export/asr/models/encoders/contextual_block_xformer.py
@@ -117,8 +117,13 @@ class ContextualBlockXformerEncoder(nn.Module, AbsExportModel):
             addin = addin * self.xscale + pos_enc_addin
 
         prev_addin = torch.cat([prev_addin, addin], dim=1)[:, is_first[0]].unsqueeze(1)
-        xs_pad = xs_pad * self.xscale + pos_enc_xs
-        ys_chunk = torch.cat([prev_addin, xs_pad, addin], dim=1).unsqueeze(1)
+
+        xs_pad = xs_pad * self.xscale + pos_enc_xs[:, :xs_pad.size(1)]
+
+        xs_chunk = torch.zeros(xs_pad.size(0), self.block_size, xs_pad.size(2))
+        xs_chunk[:, :xs_pad.size(1)] = xs_pad
+        
+        ys_chunk = torch.cat([prev_addin, xs_chunk, addin], dim=1).unsqueeze(1)
 
         next_encoder_ctx = past_encoder_ctx * 0
 

--- a/espnet_onnx/export/asr/models/encoders/contextual_block_xformer.py
+++ b/espnet_onnx/export/asr/models/encoders/contextual_block_xformer.py
@@ -122,7 +122,7 @@ class ContextualBlockXformerEncoder(nn.Module, AbsExportModel):
 
         xs_chunk = torch.zeros(xs_pad.size(0), self.block_size, xs_pad.size(2))
         xs_chunk[:, : xs_pad.size(1)] = xs_pad
-        
+
         ys_chunk = torch.cat([prev_addin, xs_chunk, addin], dim=1).unsqueeze(1)
 
         next_encoder_ctx = past_encoder_ctx * 0

--- a/espnet_onnx/export/asr/models/encoders/contextual_block_xformer.py
+++ b/espnet_onnx/export/asr/models/encoders/contextual_block_xformer.py
@@ -118,11 +118,11 @@ class ContextualBlockXformerEncoder(nn.Module, AbsExportModel):
 
         prev_addin = torch.cat([prev_addin, addin], dim=1)[:, is_first[0]].unsqueeze(1)
 
-        xs_pad = xs_pad * self.xscale + pos_enc_xs[:, :xs_pad.size(1)]
+        xs_pad = xs_pad * self.xscale + pos_enc_xs[:, : xs_pad.size(1)]
 
         xs_chunk = torch.zeros(xs_pad.size(0), self.block_size, xs_pad.size(2))
-        xs_chunk[:, :xs_pad.size(1)] = xs_pad
-        
+        xs_chunk[:, : xs_pad.size(1)] = xs_pad
+
         ys_chunk = torch.cat([prev_addin, xs_chunk, addin], dim=1).unsqueeze(1)
 
         next_encoder_ctx = past_encoder_ctx * 0


### PR DESCRIPTION
The final word was not correctly calculated with the exported contextual block.

- Padding was required before calculating the contextual encoder blocks.