### PR TITLE
[Bugfix]onnx version

### DIFF
--- a/demo/tts_onnx_demo.ipynb
+++ b/demo/tts_onnx_demo.ipynb
@@ -25,6 +25,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -35,7 +36,7 @@
     "- torch >= 1.11.0 (already installed in Colab)\n",
     "- espnet\n",
     "- espnet_model_zoo\n",
-    "- onnx\n",
+    "- onnx == 1.14\n",
     "\n",
     "`torch`, `espnet`, `espnet_model_zoo`, `onnx` is required to run the exportation demo."
    ]
@@ -50,10 +51,10 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -U espnet_onnx espnet espnet_model_zoo onnx\n",
+    "!pip install -U espnet_onnx espnet espnet_model_zoo\n",
     "\n",
     "# in this demo, we need to update scipy to avoid an error\n",
-    "!pip install -U scipy numpy==1.23.5 pyworld==0.3.2"
+    "!pip install -U scipy numpy==1.23.5 pyworld==0.3.2  onnx==1.14"
    ]
   },
   {

--- a/docs/ASRSupported.md
+++ b/docs/ASRSupported.md
@@ -4,95 +4,95 @@
 
 | arch name                          | supported |
 | ---------------------------------- | --------- |
-| ConformerEncoder                   | ◯         |
-| ContextualBlockConformerEncoder    | ◯         |
-| ContextualBlockTransformerEncoderx | ◯         |
-| FairseqHubertEncoder               | x         |
-| RNNEncoder                         | ◯         |
-| TransformerEncoder                 | ◯         |
-| VGGRNNEncoderx                     | ◯         |
-| FairSeqWav2Vec2Encoder             | x         |
-| FairseqHubertEncoder               | x         |
-| FairseqHubertPretrainEncoder       | x         |
-| LongformerEncoder                  | x         |
-| BranchformerEncoder                | ◯         |
-| E-BranchformerEncoder              | ◯         |
+| ConformerEncoder                   | Yes       |
+| ContextualBlockConformerEncoder    | Yes       |
+| ContextualBlockTransformerEncoderx | Yes       |
+| FairseqHubertEncoder               | No        |
+| RNNEncoder                         | Yes       |
+| TransformerEncoder                 | Yes       |
+| VGGRNNEncoderx                     | Yes       |
+| FairSeqWav2Vec2Encoder             | No        |
+| FairseqHubertEncoder               | No        |
+| FairseqHubertPretrainEncoder       | No        |
+| LongformerEncoder                  | No        |
+| BranchformerEncoder                | Yes       |
+| E-BranchformerEncoder              | Yes       |
 
 
 **Decoder**
 
 | arch name                                  | supported |
 | ------------------------------------------ | --------- |
-| RNNDecoder                                 | ◯         |
-| TransformerDecoder                         | ◯         |
-| LightweightConvolutionTransformerDecoder   | ◯         |
-| LightweightConvolution2DTransformerDecoder | ◯         |
-| DynamicConvolutionTransformerDecoder       | x         |
-| DynamicConvolution2DTransformerDecoder     | x         |
-| TransducerDecoder                          | ◯         |
-| MLMDecoder                                 | x         |
+| RNNDecoder                                 | Yes       |
+| TransformerDecoder                         | Yes       |
+| LightweightConvolutionTransformerDecoder   | Yes       |
+| LightweightConvolution2DTransformerDecoder | Yes       |
+| DynamicConvolutionTransformerDecoder       | No        |
+| DynamicConvolution2DTransformerDecoder     | No        |
+| TransducerDecoder                          | Yes       |
+| MLMDecoder                                 | No        |
 
 **Language Model**
 
 | arch name       | supported |
 | --------------- | --------- |
-| SequentialRNNLM | ◯         |
-| TransformerLM   | ◯         |
+| SequentialRNNLM | Yes       |
+| TransformerLM   | Yes       |
 
 **frontend**
 
 | arch name       | supported |
 | --------------- | --------- |
-| DefaultFrontend | ◯         |
-| SlidingWindow   | x         |
-| HuBERT          | ◯         |
-| Wav2Vec         | x         |
-| FusedFrontends  | x         |
+| DefaultFrontend | Yes       |
+| SlidingWindow   | No        |
+| HuBERT          | Yes       |
+| Wav2Vec         | No        |
+| FusedFrontends  | No        |
 
 **normalize**
 
 | arch name    | supported |
 | ------------ | --------- |
-| GlobalMVN    | ◯         |
-| UtteranceMVN | ◯         |
+| GlobalMVN    | Yes       |
+| UtteranceMVN | Yes       |
 
 **PositionalEmbedding**
 
 | arch name                   | supported |
 | --------------------------- | --------- |
-| PositionalEncoding          | ◯         |
-| ScaledPositionalEncoding    | ◯         |
-| LegacyRelPositionalEncoding | ◯         |
-| RelPositionalEncoding       | ◯         |
-| StreamPositionalEncoding    | ◯         |
+| PositionalEncoding          | Yes       |
+| ScaledPositionalEncoding    | Yes       |
+| LegacyRelPositionalEncoding | Yes       |
+| RelPositionalEncoding       | Yes       |
+| StreamPositionalEncoding    | Yes       |
 
 **Attention**
 
 | arch name               | supported |
 | ----------------------- | --------- |
-| NoAtt                   | ◯         |
-| AttDot                  | ◯         |
-| AttAdd                  | ◯         |
-| AttLoc                  | ◯         |
-| AttCov                  | ◯         |
-| AttLoc2D                | x         |
-| AttLocRec               | x         |
-| AttCovLoc               | ◯         |
-| AttMultiHeadDot         | x         |
-| AttMultiHeadAdd         | x         |
-| AttMultiHeadLoc         | x         |
-| AttMultiHeadMultiResLoc | x         |
-| AttForward              | x         |
-| AttForwardTA            | x         |
+| NoAtt                   | Yes       |
+| AttDot                  | Yes       |
+| AttAdd                  | Yes       |
+| AttLoc                  | Yes       |
+| AttCov                  | Yes       |
+| AttLoc2D                | No        |
+| AttLocRec               | No        |
+| AttCovLoc               | Yes       |
+| AttMultiHeadDot         | No        |
+| AttMultiHeadAdd         | No        |
+| AttMultiHeadLoc         | No        |
+| AttMultiHeadMultiResLoc | No        |
+| AttForward              | No        |
+| AttForwardTA            | No        |
 
 **pre encoder**
 The following shows the encoder module that support preencoder export and inference.
 | arch name       | supported |
 | --------------- | --------- |
-| RNN             | ◯         |
-| Transformer     | ◯         |
-| Conformer       | ◯         |
-| ContextualBlock | x         |
+| RNN             | Yes       |
+| Transformer     | Yes       |
+| Conformer       | Yes       |
+| ContextualBlock | No        |
 
 **post encoder**
 not supported.

--- a/docs/TTSSupported.md
+++ b/docs/TTSSupported.md
@@ -16,25 +16,25 @@
 
 | arch name       | supported |
 | --------------- | --------- |
-| ParallelWaveGAN | ◯         |
-| MelGAN          | ◯         |
-| HiFiGAN         | ◯         |
-| StyleMelGAN     | x         |
+| ParallelWaveGAN | yes       |
+| MelGAN          | yes       |
+| HiFiGAN         | yes       |
+| StyleMelGAN     | no        |
 
 **Attention**
 
 | arch name    | supported |
 | ------------ | --------- |
-| AttLoc       | ◯         |
-| AttForward   | x         |
-| AttForwardTA | x         |
+| AttLoc       | yes       |
+| AttForward   | no        |
+| AttForwardTA | no        |
 
 **PositionalEmbedding**
 
 | arch name                   | supported |
 | --------------------------- | --------- |
-| PositionalEncoding          | ◯         |
-| ScaledPositionalEncoding    | ◯         |
-| LegacyRelPositionalEncoding | ◯         |
-| RelPositionalEncoding       | ◯         |
-| StreamPositionalEncoding    | ◯         |
+| PositionalEncoding          | yes       |
+| ScaledPositionalEncoding    | yes       |
+| LegacyRelPositionalEncoding | yes       |
+| RelPositionalEncoding       | yes       |
+| StreamPositionalEncoding    | yes       |

--- a/tools/requirements_export.txt
+++ b/tools/requirements_export.txt
@@ -8,7 +8,7 @@ g2p_en
 jamo
 espnet
 espnet_model_zoo
-onnx
+onnx==1.14
 espnet_tts_frontend
 coloredlogs
 sympy

--- a/tools/requirements_test.txt
+++ b/tools/requirements_test.txt
@@ -5,7 +5,7 @@ typeguard==2.13.3
 g2p_en
 jamo
 espnet_model_zoo
-onnx>=1.13
+onnx==1.14
 coloredlogs
 sympy
 protobuf==3.20.2


### PR DESCRIPTION
This PR addresses a bug reported in issue #98.
We need to choose the `onnx==1.14` to run scripts. 
In this PR I changed the onnx version.

**Changes Made**
1. Updated the ONNX version to resolve the bug.
2. Made minor modifications to the documentation of the supported archtecture.

